### PR TITLE
Improve particles blend mode update for better batching

### DIFF
--- a/starling/display/BlendMode.hx
+++ b/starling/display/BlendMode.hx
@@ -91,6 +91,21 @@ class BlendMode
         if (sBlendModes.exists(modeName)) return sBlendModes[modeName];
         else throw new ArgumentError("Blend mode not found: " + modeName);
     }
+
+    /** Returns allready registered blend mode by
+    * given blend mode factors. Returns null if not exist.*/
+    public static function getByFactors(srcFactor:Context3DBlendFactor, dstFactor:Context3DBlendFactor):Null<BlendMode>
+    {
+        if (sBlendModes == null) registerDefaults();
+
+        for (registeredBlendMode in sBlendModes)
+        {
+            if (registeredBlendMode.sourceFactor == srcFactor && registeredBlendMode.destinationFactor == dstFactor)
+                return registeredBlendMode;
+        }
+        
+        return null;
+    }
     
     /** Registers a blending mode under a certain name. */
     public static function register(name:String, srcFactor:Context3DBlendFactor, dstFactor:Context3DBlendFactor):BlendMode

--- a/starling/extensions/ParticleSystem.hx
+++ b/starling/extensions/ParticleSystem.hx
@@ -109,9 +109,17 @@ class ParticleSystem extends Mesh implements IAnimatable
         {
             _vertexData.premultipliedAlpha = false;
         }
-
-        blendMode = _blendFactorSource + ", " + _blendFactorDestination;
-        BlendMode.register(blendMode, _blendFactorSource, _blendFactorDestination);
+        
+        var registeredBlendMode:BlendMode = BlendMode.getByFactors(_blendFactorSource, _blendFactorDestination);
+        if (registeredBlendMode != null)
+        {
+            blendMode = registeredBlendMode.name;
+        }
+        else
+        {
+            blendMode = _blendFactorSource + ", " + _blendFactorDestination;
+            BlendMode.register(blendMode, _blendFactorSource, _blendFactorDestination);
+        }
     }
     
     private function createParticle():Particle

--- a/starling/textures/ConcreteRectangleTexture.hx
+++ b/starling/textures/ConcreteRectangleTexture.hx
@@ -46,7 +46,7 @@ import starling.utils.Execute.execute;
     /** @inheritDoc */
     override public function uploadBitmapData(data:BitmapData, async:Dynamic=null):Void
     {
-        if (Std.is(async, Function))
+        if (async != null && Std.is(async, Function))
             _textureReadyCallback = cast async;
 
         upload(data, async != null);


### PR DESCRIPTION
The problem is that `ParticleSystem` always trying to [register](https://github.com/openfl/starling/blob/dc0e69e93687e7c51df415c1c3f2455f3ef9bc11/starling/extensions/ParticleSystem.hx#L114) new blend mode even if it is one of standard (`normal`, `add` etc). It will never batch with the rest of the game even if `batchable = true` and it is use the same texture atlas and blend mode. It can be usefull for another extensions to reuse existing blend modes without knowing their names.