### PR TITLE
Remove untyped Function usages

### DIFF
--- a/starling/display/Mesh.hx
+++ b/starling/display/Mesh.hx
@@ -21,7 +21,6 @@ import starling.rendering.VertexData;
 import starling.rendering.VertexDataFormat;
 import starling.styles.MeshStyle;
 import starling.textures.Texture;
-import starling.utils.Execute.execute;
 import starling.utils.MatrixUtil;
 import starling.utils.MeshUtil;
 

--- a/starling/display/MeshBatch.hx
+++ b/starling/display/MeshBatch.hx
@@ -11,6 +11,7 @@
 package starling.display;
 
 import openfl.geom.Matrix;
+import starling.rendering.Effect;
 
 import starling.rendering.IndexData;
 import starling.rendering.MeshEffect;
@@ -255,7 +256,7 @@ class MeshBatch extends Mesh
             __effect.dispose();
 
         __effect = style.createEffect();
-        __effect.onRestore = __setVertexAndIndexDataChanged;
+        __effect.onRestore = function(effect:Effect):Void{__setVertexAndIndexDataChanged();};
 
         __setVertexAndIndexDataChanged(); // we've got a new set of buffers!
     }

--- a/starling/rendering/BatchProcessor.hx
+++ b/starling/rendering/BatchProcessor.hx
@@ -10,7 +10,6 @@
 
 package starling.rendering;
 
-import haxe.Constraints.Function;
 import openfl.geom.Matrix;
 import openfl.utils.Dictionary;
 import openfl.Vector;
@@ -18,6 +17,8 @@ import openfl.Vector;
 import starling.display.Mesh;
 import starling.display.MeshBatch;
 import starling.utils.MeshSubset;
+
+typedef BatchCompleteHandler = MeshBatch->Void;
 
 /** This class manages a list of mesh batches of different types;
  *  it acts as a "meta" MeshBatch that initiates all rendering.
@@ -28,7 +29,7 @@ class BatchProcessor
     private var _batchPool:BatchPool;
     private var _currentBatch:MeshBatch;
     private var _currentStyleType:Class<Dynamic>;
-    private var _onBatchComplete:Function;
+    private var _onBatchComplete:BatchCompleteHandler;
     private var _cacheToken:BatchToken;
 
     // helper objects
@@ -164,9 +165,9 @@ class BatchProcessor
     /** This callback is executed whenever a batch is finished and replaced by a new one.
      *  The finished MeshBatch is passed to the callback. Typically, this callback is used
      *  to actually render it. */
-    public var onBatchComplete(get, set):Function;
-    private function get_onBatchComplete():Function { return _onBatchComplete; }
-    private function set_onBatchComplete(value:Function):Function { return _onBatchComplete = value; }
+    public var onBatchComplete(get, set):BatchCompleteHandler;
+    private function get_onBatchComplete():BatchCompleteHandler { return _onBatchComplete; }
+    private function set_onBatchComplete(value:BatchCompleteHandler):BatchCompleteHandler { return _onBatchComplete = value; }
 }
 
 class BatchPool

--- a/starling/rendering/Effect.hx
+++ b/starling/rendering/Effect.hx
@@ -10,8 +10,6 @@
 
 package starling.rendering;
 
-import haxe.Constraints.Function;
-
 import openfl.display3D.Context3D;
 import openfl.display3D.Context3DProgramType;
 import openfl.display3D.IndexBuffer3D;
@@ -23,7 +21,8 @@ import openfl.utils.Dictionary;
 
 import starling.core.Starling;
 import starling.errors.MissingContextError;
-import starling.utils.Execute.execute;
+
+typedef EffectRestoredCallback = Effect->Void;
 
 /** An effect encapsulates all steps of a Stage3D draw operation. It configures the
  *  render context and sets up shader programs as well as index- and vertex-buffers, thus
@@ -111,7 +110,7 @@ class Effect
     private var _indexBufferUsesQuadLayout:Bool;
 
     private var _mvpMatrix3D:Matrix3D;
-    private var _onRestore:Function;
+    private var _onRestore:EffectRestoredCallback;
     private var _programBaseName:String;
 
     // helper objects
@@ -138,7 +137,8 @@ class Effect
     private function onContextCreated(event:Event):Void
     {
         purgeBuffers();
-        execute(_onRestore, [this]);
+        if(_onRestore != null)
+            _onRestore(this);
     }
 
     /** Purges one or both of the vertex- and index-buffers. */
@@ -361,9 +361,9 @@ class Effect
     /** The function that you provide here will be called after a context loss.
      *  Call both "upload..." methods from within the callback to restore any vertex or
      *  index buffers. The callback will be executed with the effect as its sole parameter. */
-    public var onRestore(get, set):Function;
-    private function get_onRestore():Function { return _onRestore; }
-    private function set_onRestore(value:Function):Function { return _onRestore = value; }
+    public var onRestore(get, set):EffectRestoredCallback;
+    private function get_onRestore():EffectRestoredCallback { return _onRestore; }
+    private function set_onRestore(value:EffectRestoredCallback):EffectRestoredCallback { return _onRestore = value; }
 
     /** The data format that this effect requires from the VertexData that it renders:
      *  <code>"position:float2"</code> */

--- a/starling/rendering/RenderState.hx
+++ b/starling/rendering/RenderState.hx
@@ -10,7 +10,6 @@
 
 package starling.rendering;
 
-import haxe.Constraints.Function;
 import openfl.display3D.Context3DCompareMode;
 import openfl.display3D.Context3DTriangleFace;
 import openfl.display3D.textures.TextureBase;
@@ -27,6 +26,8 @@ import starling.utils.MathUtil;
 import starling.utils.MatrixUtil;
 import starling.utils.Pool;
 import starling.utils.RectangleUtil;
+
+typedef DrawRequiredHandler = Void->Void;
 
 /** The RenderState stores a combination of settings that are currently used for rendering.
  *  This includes modelview and transformation matrices as well as context3D related settings.
@@ -87,7 +88,7 @@ class RenderState
     private var _miscOptions:UInt = 0;
     private var _clipRect:Rectangle;
     private var _renderTarget:Texture;
-    private var _onDrawRequired:Function;
+    private var _onDrawRequired:DrawRequiredHandler;
     private var _modelviewMatrix3D:Matrix3D;
     private var _projectionMatrix3D:Matrix3D;
     private var _projectionMatrix3DRev:UInt;
@@ -474,7 +475,7 @@ class RenderState
      *  This callback is executed whenever a state change requires a draw operation.
      *  This is the case if blend mode, render target, culling or clipping rectangle
      *  are changing. */
-    @:allow(starling) private var onDrawRequired(get, set):Function;
-    private function get_onDrawRequired():Function { return _onDrawRequired; }
-    private function set_onDrawRequired(value:Function):Function { return _onDrawRequired = value; }
+    @:allow(starling) private var onDrawRequired(get, set):DrawRequiredHandler;
+    private function get_onDrawRequired():DrawRequiredHandler { return _onDrawRequired; }
+    private function set_onDrawRequired(value:DrawRequiredHandler):DrawRequiredHandler { return _onDrawRequired = value; }
 }

--- a/starling/text/MiniBitmapFont.hx
+++ b/starling/text/MiniBitmapFont.hx
@@ -22,6 +22,7 @@ import haxe.io.BytesInput;
 import haxe.zip.InflateImpl;
 
 import starling.textures.Texture;
+import starling.textures.ConcreteTexture;
 
 /** @private
  *  This class contains constants for the 'MINI' bitmap font. It's done that way to avoid
@@ -399,10 +400,10 @@ class MiniBitmapFont
         bitmapData.dispose();
         bitmapData = null;
 
-        texture.root.onRestore = function():Void
+        texture.root.onRestore = function(textureRoot:ConcreteTexture):Void
         {
             bitmapData = getBitmapData();
-            texture.root.uploadBitmapData(bitmapData);
+            textureRoot.uploadBitmapData(bitmapData);
             bitmapData.dispose();
             bitmapData = null;
         };

--- a/starling/text/TrueTypeCompositor.hx
+++ b/starling/text/TrueTypeCompositor.hx
@@ -15,6 +15,7 @@ import openfl.geom.Matrix;
 import openfl.text.AntiAliasType;
 import openfl.text.TextField;
 
+import starling.textures.ConcreteTexture;
 import starling.display.MeshBatch;
 import starling.display.Quad;
 import starling.textures.Texture;
@@ -55,10 +56,10 @@ class TrueTypeCompositor implements ITextCompositor
         var bitmapData:BitmapDataEx = renderText(width, height, text, format, options);
 
         texture = Texture.fromBitmapData(bitmapData, false, false, bitmapData.scale, textureFormat);
-        texture.root.onRestore = function():Void
+        texture.root.onRestore = function(textureRoot:ConcreteTexture):Void
         {
             bitmapData = renderText(width, height, text, format, options);
-            texture.root.uploadBitmapData(bitmapData);
+            textureRoot.uploadBitmapData(bitmapData);
             bitmapData.dispose();
             bitmapData = null;
         };

--- a/starling/textures/ConcretePotTexture.hx
+++ b/starling/textures/ConcretePotTexture.hx
@@ -10,8 +10,8 @@
 
 package starling.textures;
 
-import haxe.Constraints.Function;
 import haxe.Timer;
+import starling.textures.ConcreteTexture.TextureUploadedCallback;
 
 import openfl.display.BitmapData;
 import openfl.display3D.textures.TextureBase;
@@ -26,7 +26,6 @@ import openfl.utils.ByteArray;
 
 import starling.core.Starling;
 import starling.utils.MathUtil;
-import starling.utils.Execute.execute;
 
 /** @private
  *
@@ -34,7 +33,7 @@ import starling.utils.Execute.execute;
  *  For internal use only. */
 @:allow(starling) class ConcretePotTexture extends ConcreteTexture
 {
-    private var _textureReadyCallback:Function;
+    private var _textureReadyCallback:TextureUploadedCallback;
 
     private static var sMatrix:Matrix = new Matrix();
     private static var sRectangle:Rectangle = new Rectangle();
@@ -72,13 +71,13 @@ import starling.utils.Execute.execute;
     }
 
     /** @inheritDoc */
-    override public function uploadBitmapData(data:BitmapData, async:Dynamic=null):Void
+    override public function uploadBitmapData(data:BitmapData, async:TextureUploadedCallback=null):Void
     {
         var buffer:BitmapData = null;
-        var isAsync:Bool = Std.is(async, Function) || async == true;
+        var isAsync:Bool = async != null;
 
-        if (Std.is(async, Function))
-            _textureReadyCallback = cast async;
+        if (isAsync)
+            _textureReadyCallback = async;
 
         if (data.width != nativeWidth || data.height != nativeHeight)
         {
@@ -122,14 +121,14 @@ import starling.utils.Execute.execute;
     override private function get_isPotTexture():Bool { return true; }
 
     /** @inheritDoc */
-    override public function uploadAtfData(data:ByteArray, offset:Int = 0, async:Dynamic = null):Void
+    override public function uploadAtfData(data:ByteArray, offset:Int = 0, async:TextureUploadedCallback = null):Void
     {
         data.endian = BIG_ENDIAN;
-        var isAsync:Bool = Std.is(async, Function) || async == true;
+        var isAsync:Bool = async != null;
 
-        if (Std.is(async, Function))
+        if (isAsync)
         {
-            _textureReadyCallback = cast async;
+            _textureReadyCallback = async;
             base.addEventListener(Event.TEXTURE_READY, onTextureReady);
         }
 
@@ -180,7 +179,8 @@ import starling.utils.Execute.execute;
         base.removeEventListener(Event.TEXTURE_READY, onTextureReady);
         base.removeEventListener(ErrorEvent.ERROR, onTextureReady);
 
-        execute(_textureReadyCallback, [this, event]);
+        if(_textureReadyCallback != null)
+            _textureReadyCallback(this);
         _textureReadyCallback = null;
     }
 

--- a/starling/textures/ConcreteRectangleTexture.hx
+++ b/starling/textures/ConcreteRectangleTexture.hx
@@ -10,7 +10,6 @@
 
 package starling.textures;
 
-import haxe.Constraints.Function;
 import haxe.Timer;
 
 import openfl.display.BitmapData;
@@ -21,7 +20,7 @@ import openfl.events.ErrorEvent;
 import openfl.events.Event;
 
 import starling.core.Starling;
-import starling.utils.Execute.execute;
+import starling.textures.ConcreteTexture.TextureUploadedCallback;
 
 /** @private
  *
@@ -29,7 +28,7 @@ import starling.utils.Execute.execute;
  *  For internal use only. */
 @:allow(starling) class ConcreteRectangleTexture extends ConcreteTexture
 {
-    private var _textureReadyCallback:Function;
+    private var _textureReadyCallback:TextureUploadedCallback;
 
     private static var sAsyncUploadEnabled:Bool = false;
 
@@ -44,10 +43,10 @@ import starling.utils.Execute.execute;
     }
 
     /** @inheritDoc */
-    override public function uploadBitmapData(data:BitmapData, async:Dynamic=null):Void
+    override public function uploadBitmapData(data:BitmapData, async:TextureUploadedCallback=null):Void
     {
-        if (async != null && Std.is(async, Function))
-            _textureReadyCallback = cast async;
+        if (async != null)
+            _textureReadyCallback = async;
 
         upload(data, async != null);
         setDataUploaded();
@@ -111,7 +110,8 @@ import starling.utils.Execute.execute;
         base.removeEventListener(Event.TEXTURE_READY, onTextureReady);
         base.removeEventListener(ErrorEvent.ERROR, onTextureReady);
 
-        execute(_textureReadyCallback, [this, event]);
+        if (_textureReadyCallback != null)
+            _textureReadyCallback(this);
         _textureReadyCallback = null;
     }
 

--- a/starling/textures/ConcreteVideoTexture.hx
+++ b/starling/textures/ConcreteVideoTexture.hx
@@ -10,7 +10,7 @@
 
 package starling.textures;
 
-import haxe.Constraints.Function;
+import starling.textures.ConcreteTexture.TextureUploadedCallback;
 
 import openfl.display3D.Context3DTextureFormat;
 import openfl.display3D.textures.TextureBase;
@@ -18,7 +18,6 @@ import openfl.display3D.textures.VideoTexture;
 import openfl.events.Event;
 
 import starling.core.Starling;
-import starling.utils.Execute.execute;
 
 /** @private
  *
@@ -26,7 +25,7 @@ import starling.utils.Execute.execute;
  *  For internal use only. */
 @:allow(starling) class ConcreteVideoTexture extends ConcreteTexture
 {
-    private var _textureReadyCallback:Function;
+    private var _textureReadyCallback:TextureUploadedCallback;
     private var _disposed:Bool;
 
     /** Creates a new instance with the given parameters.
@@ -66,7 +65,7 @@ import starling.utils.Execute.execute;
 
     /** @private */
     override private function attachVideo(type:String, attachment:Dynamic,
-                                           onComplete:Function=null):Void
+                                           onComplete:TextureUploadedCallback=null):Void
     {
         _textureReadyCallback = onComplete;
         var method = Reflect.field(base, "attach" + type);
@@ -79,7 +78,8 @@ import starling.utils.Execute.execute;
     private function onTextureReady(event:Event):Void
     {
         base.removeEventListener(Event.TEXTURE_READY, onTextureReady);
-        execute(_textureReadyCallback, [this]);
+        if (_textureReadyCallback != null)
+            _textureReadyCallback(this);
         _textureReadyCallback = null;
     }
 

--- a/starling/textures/TextureOptions.hx
+++ b/starling/textures/TextureOptions.hx
@@ -10,9 +10,8 @@
 
 package starling.textures;
 
-import haxe.Constraints.Function;
-
 import starling.core.Starling;
+import starling.textures.ConcreteTexture.TextureUploadedCallback;
 
 /** The TextureOptions class specifies options for loading textures with the
  *  <code>Texture.fromData</code> and <code>Texture.fromTextureBase</code> methods. */
@@ -24,7 +23,7 @@ class TextureOptions
     private var _optimizeForRenderToTexture:Bool = false;
     private var _premultipliedAlpha:Bool;
     private var _forcePotTexture:Bool;
-    private var _onReady:Function = null;
+    private var _onReady:TextureUploadedCallback = null;
 
     /** Creates a new instance with the given options. */
     public function new(scale:Float=1.0, mipMapping:Bool=false, 
@@ -91,9 +90,9 @@ class TextureOptions
      *
      *  @default null
      */
-    public var onReady(get, set):Function;
-    private function get_onReady():Function { return _onReady; }
-    private function set_onReady(value:Function):Function { return _onReady = value; }
+    public var onReady(get, set):TextureUploadedCallback;
+    private function get_onReady():TextureUploadedCallback { return _onReady; }
+    private function set_onReady(value:TextureUploadedCallback):TextureUploadedCallback { return _onReady = value; }
 
     /** Indicates if the alpha values are premultiplied into the RGB values. This is typically
      *  true for textures created from BitmapData and false for textures created from ATF data.


### PR DESCRIPTION
One of the main lacks of AS3 language is the miss of `callback` signatures. This make impossible for compiler to check the correctness of provided functions due compilation. In this PR I cleared and standardize most of the situations using Haxe syntax features.

But in a few cases I had to remove some features:
1. `ConcreteTexture->uploadBitmap`, `ConcreteTexture->uploadBitmapData` and 
 `ConcreteTexture->uploadAtfData` in AS3 version [apply](https://github.com/Gamua/Starling-Framework/blob/master/starling/src/starling/textures/ConcreteTexture.as#L119) `Bool` or `Callback` as async param. But `Texture.fromBitmap`, `Texture.fromAtfData` static factory apply only `Callback` as async argument. In this case i removed `Bool` argument possibility to unify and simplify signatures.
2. `ConcreteTexture->uploadBitmap` and `ConcreteTexture->uploadBitmapData` async `Callback` in AS3 **optionally** [takes](https://github.com/Gamua/Starling-Framework/blob/9324d3b59b87ae5c25eb5e29d60b04163bb778b1/starling/src/starling/textures/ConcreteTexture.as#L125) `ErrorEvent` as second argument. It has been removed too. (In this case may be `Texture` should be `EventDispatcher` and dispatch `ErrorEvent` if thrown?)

All other changes must be equal the AS3 but writed in strictly-typed manner.

**Additional proposal**:
I understand that most things are done for backward compatibility, but may be we can unify all untyped `Function` usages:
1. `EventDispatcher` [invoke](https://github.com/openfl/starling/blob/master/starling/events/EventDispatcher.hx#L166-L178) and `MovieClipFrame` [executeAction ](https://github.com/openfl/starling/blob/master/starling/display/MovieClip.hx#L477-L496) use the same ugly technic as Starling [execute](https://github.com/openfl/starling/blob/master/starling/utils/Execute.hx) helper. On some platforms `func.length` allocates additional array to just check the number of args which can couse intensive GC.
We can make listener signature to `Event->Void` for `EventDispatcher.invoke`, create `MoveClipFrameEvent` : `MovieClip->Int->Void` for `MovieClipFrame.executeAction` and remove `execute` helper usage from Starling core classes (it's allmost done in this PR).


