### PR TITLE
Fix MeshStyle constructor DCE

### DIFF
--- a/starling/styles/MeshStyle.hx
+++ b/starling/styles/MeshStyle.hx
@@ -109,13 +109,13 @@ class MeshStyle extends EventDispatcher
 
     /** Creates a new MeshStyle instance.
      *  Subclasses must provide a constructor that can be called without any arguments. */
-    public function new()
+    @:keep public function new()
     {
         super();
         _textureSmoothing = TextureSmoothing.BILINEAR;
         _type = Type.getClass(this);
     }
-
+    
     /** Copies all properties of the given style to the current instance (or a subset, if the
      *  classes don't match). Must be overridden by all subclasses!
      */


### PR DESCRIPTION
There are direct calls of `new MeshStyle()` only in `StatsDisplay`. If StatsDisplay never used and project compiled with DCE enabled there will be error in non flash targets.