### PR TITLE
Add starling demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Tell haxelib where your development copy of Starling is installed:
 To return to release builds:
 
     haxelib dev starling
+    
+Sample Projects
+---------------
+
+- [StarlingDemoHaxe](https://github.com/zacdevon/StarlingDemoHaxe) - A simple demo mobile app built with FlashDevelop, Adobe AIR and Haxe/OpenFL/Starling


### PR DESCRIPTION
Add a link to my starling demo app, which acts as a "quick start" project. The project configuration was fully done by Joshua Granick in this [OpenFL thread](http://community.openfl.org/t/getting-started-with-haxe-and-starling/9919/12) and supports flash/air targets as well as the others. Simply coded and well commented. All code is released under MIT.