### PR TITLE
SystemUtil fix: executeWhenApplicationIsActive should always act as a…

### DIFF
--- a/src/starling/utils/SystemUtil.hx
+++ b/src/starling/utils/SystemUtil.hx
@@ -70,6 +70,12 @@ class SystemUtil
 
         try
         {
+			#if flash
+			var nativeAppClass:Dynamic = Type.resolveClass("flash.desktop::NativeApplication");
+			if (nativeAppClass == null)
+				throw new Error("Not Air");
+			#end
+			
             //var nativeAppClass:Object = getDefinitionByName("flash.desktop::NativeApplication");
             //var nativeApp:EventDispatcher = nativeAppClass["nativeApplication"] as EventDispatcher;
             var nativeApp = Lib.current;


### PR DESCRIPTION
…ctive in Flash (caused freeze in rendermode GPU when window not active)

As discussed here: http://community.openfl.org/t/starling-flattening-flash-target-gpu-as-wmode-different-behavior/10141/7