### PR TITLE
Fix filters for containers that contain flatten sprites

### DIFF
--- a/starling/display/Sprite.hx
+++ b/starling/display/Sprite.hx
@@ -232,10 +232,11 @@ class Sprite extends DisplayObjectContainer
             
             var alpha:Float = parentAlpha * this.alpha;
             var numBatches:Int = mFlattenedContents.length;
-            var mvpMatrix:Matrix3D = support.mvpMatrix3D;
             
             support.finishQuadBatch();
             support.raiseDrawCount(numBatches);
+            
+            var mvpMatrix:Matrix3D = support.mvpMatrix3D;
             
             for (i in 0...numBatches)
             {


### PR DESCRIPTION
When filters are applied on containers that contain flatten object, the filter will be incorrectly drawn because `support.finishQuadBatch();` will overwrite the RenderSupport's `mMvpMatrix3D` calculated previously in `var mvpMatrix:Matrix3D = support.mvpMatrix3D;`