### PR TITLE
Fix RenderTexture dispose() texture

### DIFF
--- a/src/starling/textures/RenderTexture.hx
+++ b/src/starling/textures/RenderTexture.hx
@@ -155,13 +155,11 @@ class RenderTexture extends SubTexture
     /** @inheritDoc */
     public override function dispose():Void
     {
-        if (isDoubleBuffered)
-        {
-            _bufferTexture.dispose();
-            _helperImage.dispose();
-        }
+        if (_helperImage != null) _helperImage.dispose();
+        if ((parent != _bufferTexture) && (_bufferTexture != null)) _bufferTexture.dispose();
+        if (parent != _activeTexture) _activeTexture.dispose();
         
-        super.dispose(); // will take care of '_activeTexture'
+        super.dispose(); // will take care of parent (either _bufferTexture or _activeTexture)
     }
     
     /** Draws an object into the texture.

--- a/src/starling/textures/RenderTexture.hx
+++ b/src/starling/textures/RenderTexture.hx
@@ -155,15 +155,13 @@ class RenderTexture extends SubTexture
     /** @inheritDoc */
     public override function dispose():Void
     {
-        _activeTexture.dispose();
-        
         if (isDoubleBuffered)
         {
             _bufferTexture.dispose();
             _helperImage.dispose();
         }
         
-        super.dispose();
+        super.dispose(); // will take care of '_activeTexture'
     }
     
     /** Draws an object into the texture.


### PR DESCRIPTION
From [Haxegon](https://github.com/haxegon/haxegon/pull/285), _activeTexture was being disposed twice once in RenderTexture and once in SubTexture. Only dispose it in RenderTexture if SubTexture isn't going to dispose it.