### PR TITLE
fix UInt / Int comparison compilation error

### DIFF
--- a/src/starling/utils/ByteArrayUtil.hx
+++ b/src/starling/utils/ByteArrayUtil.hx
@@ -87,7 +87,7 @@ class ByteArrayUtil
      *  Pass an array that contains integers in the range 0-255. */
     public static function startsWithBytes(byteArray:ByteArray, firstBytes:Array<Int>):Bool
     {
-        if (firstBytes.length > byteArray.length) return false;
+        if ((firstBytes.length : UInt) > byteArray.length) return false;
 
         var len = firstBytes.length;
         #if commonjs


### PR DESCRIPTION
Using Haxe 4-rc2, OpenFL 8.9.1 and lime 7.5.0.

Was having this problem: 
```
Z:/dev/Haxe/haxe4_latest/lib/starling/2,5,1/src/starling/utils/ByteArrayUtil.hx:71: characters 7-43
: Comparison of Int and UInt might lead to unexpected results
```

`openfl.utils.ByteArray`'s `length` is of type `UInt`. Although it makes sense, `Array`'s `length` is of type Int, so when comparing them it will spit this error. This fixed it, but you may want to take a look at it to make it more consistent.