### PR TITLE
AtfTextureFactory does not work at all

### DIFF
--- a/src/starling/assets/AtfTextureFactory.hx
+++ b/src/starling/assets/AtfTextureFactory.hx
@@ -53,7 +53,6 @@ class AtfTextureFactory extends AssetFactory
                 onComplete(reference.name, texture);
             };
             
-            var texture:Texture = null;
             var url:String = reference.url;
 
             try { texture = Texture.fromData(reference.data, reference.textureOptions); }


### PR DESCRIPTION
The second (duplicate) declaration of "var texture:Texture = null;" caused the onComplete function to be called with "null" - meaning you could never access this Texture using the AssetManager since it would be null (and I couldn't access a TextureAtlas that used this texture, since it never got created).