### PR TITLE
Add the ability to load webp files to starling

### DIFF
--- a/src/starling/assets/BitmapTextureFactory.hx
+++ b/src/starling/assets/BitmapTextureFactory.hx
@@ -32,13 +32,14 @@ class BitmapTextureFactory extends AssetFactory
     private static var MAGIC_NUMBERS_JPG:Array<Int> = [0xff, 0xd8];
     private static var MAGIC_NUMBERS_PNG:Array<Int> = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
     private static var MAGIC_NUMBERS_GIF:Array<Int> = [0x47, 0x49, 0x46, 0x38];
+    private static var MAGIC_NUMBERS_WEBP:Array<Int> = [0x52, 0x49, 0x46, 0x46];
 
     /** Creates a new instance. */
     public function new()
     {
         super();
-        addMimeTypes(["image/png", "image/jpg", "image/jpeg", "image/gif"]);
-        addExtensions(["png", "jpg", "jpeg", "gif"]);
+        addMimeTypes(["image/png", "image/jpg", "image/jpeg", "image/gif", "image/webp"]);
+        addExtensions(["png", "jpg", "jpeg", "gif", "webp"]);
     }
 
     /** @inheritDoc */
@@ -54,7 +55,8 @@ class BitmapTextureFactory extends AssetFactory
             var byteData:ByteArray = cast reference.data;
             return ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_PNG) ||
                     ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_JPG) ||
-                    ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_GIF);
+                    ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_GIF) ||
+                    ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_WEBP);
         }
         else return false;
     }

--- a/src/starling/assets/BitmapTextureFactory.hx
+++ b/src/starling/assets/BitmapTextureFactory.hx
@@ -38,8 +38,8 @@ class BitmapTextureFactory extends AssetFactory
     public function new()
     {
         super();
-        addMimeTypes(["image/png", "image/jpg", "image/jpeg", "image/gif", "image/webp"]);
-        addExtensions(["png", "jpg", "jpeg", "gif", "webp"]);
+        addMimeTypes(["image/png", "image/jpg", "image/jpeg", "image/gif" #if html5 , "image/webp" #end ]);
+        addExtensions(["png", "jpg", "jpeg", "gif" #if html5 , "webp" #end ]);
     }
 
     /** @inheritDoc */
@@ -55,8 +55,8 @@ class BitmapTextureFactory extends AssetFactory
             var byteData:ByteArray = cast reference.data;
             return ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_PNG) ||
                     ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_JPG) ||
-                    ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_GIF) ||
-                    ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_WEBP);
+                    ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_GIF)
+                    #if html5 || ByteArrayUtil.startsWithBytes(byteData, MAGIC_NUMBERS_WEBP #end );
         }
         else return false;
     }


### PR DESCRIPTION
Now you can load webp spritesheets (TextureAtlas) with the starling AssetManager.  Of course, this will only work in web browsers that support webp (i.e. not Safari).