### PR TITLE
Fixed for Actuate

### DIFF
--- a/src/starling/display/DisplayObject.hx
+++ b/src/starling/display/DisplayObject.hx
@@ -961,8 +961,8 @@ class DisplayObject extends EventDispatcher
      * Note that for objects in a 3D space (connected to a Sprite3D), this value might not
      * be accurate until the object is part of the display list. */
     public var width(get, set):Float;
-    private function get_width():Float { return getBounds(__parent, sHelperRect).width; }
-    private function set_width(value:Float):Float
+    @:keep private function get_width():Float { return getBounds(__parent, sHelperRect).width; }
+    @:keep private function set_width(value:Float):Float
     {
         // this method calls 'this.scaleX' instead of changing _scaleX directly.
         // that way, subclasses reacting on size changes need to override only the scaleX method.
@@ -983,8 +983,8 @@ class DisplayObject extends EventDispatcher
      * Note that for objects in a 3D space (connected to a Sprite3D), this value might not
      * be accurate until the object is part of the display list. */
     public var height(get, set):Float;
-    private function get_height():Float { return getBounds(__parent, sHelperRect).height; }
-    private function set_height(value:Float):Float
+    @:keep private function get_height():Float { return getBounds(__parent, sHelperRect).height; }
+    @:keep private function set_height(value:Float):Float
     {
         var actualHeight:Float;
         var scaleIsNaN:Bool = __scaleY != __scaleY; // avoid 'isNaN' call
@@ -1000,8 +1000,8 @@ class DisplayObject extends EventDispatcher
     
     /** The x coordinate of the object relative to the local coordinates of the parent. */
     public var x(get, set):Float;
-    private function get_x():Float { return __x; }
-    private function set_x(value:Float):Float 
+    @:keep private function get_x():Float { return __x; }
+    @:keep private function set_x(value:Float):Float
     { 
         if (__x != value)
         {
@@ -1013,8 +1013,8 @@ class DisplayObject extends EventDispatcher
     
     /** The y coordinate of the object relative to the local coordinates of the parent. */
     public var y(get, set):Float;
-    private function get_y():Float { return __y; }
-    private function set_y(value:Float):Float 
+    @:keep private function get_y():Float { return __y; }
+    @:keep private function set_y(value:Float):Float
     {
         if (__y != value)
         {
@@ -1026,8 +1026,8 @@ class DisplayObject extends EventDispatcher
     
     /** The x coordinate of the object's origin in its own coordinate space (default: 0). */
     public var pivotX(get, set):Float;
-    private function get_pivotX():Float { return __pivotX; }
-    private function set_pivotX(value:Float):Float 
+    @:keep private function get_pivotX():Float { return __pivotX; }
+    @:keep private function set_pivotX(value:Float):Float
     {
         if (__pivotX != value)
         {
@@ -1039,8 +1039,8 @@ class DisplayObject extends EventDispatcher
     
     /** The y coordinate of the object's origin in its own coordinate space (default: 0). */
     public var pivotY(get, set):Float;
-    private function get_pivotY():Float { return __pivotY; }
-    private function set_pivotY(value:Float):Float 
+    @:keep private function get_pivotY():Float { return __pivotY; }
+    @:keep private function set_pivotY(value:Float):Float
     { 
         if (__pivotY != value)
         {
@@ -1053,8 +1053,8 @@ class DisplayObject extends EventDispatcher
     /** The horizontal scale factor. '1' means no scale, negative values flip the object.
      * @default 1 */
     public var scaleX(get, set):Float;
-    private function get_scaleX():Float { return __scaleX; }
-    private function set_scaleX(value:Float):Float 
+    @:keep private function get_scaleX():Float { return __scaleX; }
+    @:keep private function set_scaleX(value:Float):Float
     { 
         if (__scaleX != value)
         {
@@ -1067,8 +1067,8 @@ class DisplayObject extends EventDispatcher
     /** The vertical scale factor. '1' means no scale, negative values flip the object.
      * @default 1 */
     public var scaleY(get, set):Float;
-    private function get_scaleY():Float { return __scaleY; }
-    private function set_scaleY(value:Float):Float 
+    @:keep private function get_scaleY():Float { return __scaleY; }
+    @:keep private function set_scaleY(value:Float):Float
     { 
         if (__scaleY != value)
         {
@@ -1081,13 +1081,13 @@ class DisplayObject extends EventDispatcher
     /** Sets both 'scaleX' and 'scaleY' to the same value. The getter simply returns the
      * value of 'scaleX' (even if the scaling values are different). @default 1 */
     public var scale(get, set):Float;
-    private function get_scale():Float { return scaleX; }
-    private function set_scale(value:Float):Float { return scaleX = scaleY = value; }
+    @:keep private function get_scale():Float { return scaleX; }
+    @:keep private function set_scale(value:Float):Float { return scaleX = scaleY = value; }
     
     /** The horizontal skew angle in radians. */
     public var skewX(get, set):Float;
-    private function get_skewX():Float { return __skewX; }
-    private function set_skewX(value:Float):Float 
+    @:keep private function get_skewX():Float { return __skewX; }
+    @:keep private function set_skewX(value:Float):Float
     {
         value = MathUtil.normalizeAngle(value);
         
@@ -1101,8 +1101,8 @@ class DisplayObject extends EventDispatcher
     
     /** The vertical skew angle in radians. */
     public var skewY(get, set):Float;
-    private function get_skewY():Float { return __skewY; }
-    private function set_skewY(value:Float):Float 
+    @:keep private function get_skewY():Float { return __skewY; }
+    @:keep private function set_skewY(value:Float):Float
     {
         value = MathUtil.normalizeAngle(value);
         
@@ -1117,8 +1117,8 @@ class DisplayObject extends EventDispatcher
     /** The rotation of the object in radians. (In Starling, all angles are measured 
      * in radians.) */
     public var rotation(get, set):Float;
-    private function get_rotation():Float { return __rotation; }
-    private function set_rotation(value:Float):Float 
+    @:keep private function get_rotation():Float { return __rotation; }
+    @:keep private function set_rotation(value:Float):Float
     {
         value = MathUtil.normalizeAngle(value);
 

--- a/src/starling/extensions/PDParticleSystem.hx
+++ b/src/starling/extensions/PDParticleSystem.hx
@@ -299,7 +299,7 @@ class PDParticleSystem extends ParticleSystem
     
     private function parseConfig(config:String):Void
     {
-        var xml = new Fast(Xml.parse(config).firstElement());
+        var xml = new haxe.xml.Access(Xml.parse(config).firstElement());
         var config = xml.node;
         _emitterXVariance = Std.parseFloat(config.sourcePositionVariance.att.x);
         _emitterYVariance = Std.parseFloat(config.sourcePositionVariance.att.y);
@@ -362,17 +362,17 @@ class PDParticleSystem extends ParticleSystem
         updateBlendMode();
     }
     
-    private function getIntValue(element:Fast):Int
+    private function getIntValue(element:haxe.xml.Access):Int
     {
         return Std.parseInt(element.att.value);
     }
     
-    private function getFloatValue(element:Fast):Float
+    private function getFloatValue(element:haxe.xml.Access):Float
     {
         return Std.parseFloat(element.att.value);
     }
 
-    private function getColor(element:Fast):ColorArgb
+    private function getColor(element:haxe.xml.Access):ColorArgb
     {
         var color:ColorArgb = new ColorArgb();
         color.red   = Std.parseFloat(element.att.red);
@@ -382,7 +382,7 @@ class PDParticleSystem extends ParticleSystem
         return color;
     }
 
-    private function getBlendFunc(element:Fast):Context3DBlendFactor
+    private function getBlendFunc(element:haxe.xml.Access):Context3DBlendFactor
     {
         var value:Int = getIntValue(element);
         switch (value)


### PR DESCRIPTION
1. added @:keep to properties to avoid issues with -dce full and -minify while tweening (for ex. with Actuate)
2. removed deprecation warning when compiling with haxe 4.x "Warning : This typedef is deprecated in favor of haxe.xml.Access"