### PR TITLE
Fix exception in removeByID on html5 target

### DIFF
--- a/src/starling/animation/Juggler.hx
+++ b/src/starling/animation/Juggler.hx
@@ -153,7 +153,7 @@ class Juggler implements IAnimatable
         {
             object = __objects[i];
 
-            if (__objectIDs[object] == objectID)
+            if (object != null && __objectIDs[object] == objectID)
             {
                 remove(object);
                 return objectID;


### PR DESCRIPTION
On html5 above string looks like
`if(this.__objectIDs.h[object.__id__] == objectID)`
and in case of object == null leads to error