### PR TITLE
fix for BlendMode.isRegistered function error when calling it early

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ cd demo
 openfl test flash
 ```
 
+Note about high-dpi support
+---------------------------
+Starling supports high-dpi devices such as 4K monitors
+For it to work you need to add this in your project file:
+```xml
+<window allow-high-dpi="true"/>
+```
+You also need to tell starling to support high resolutions in your code:
+```bash
+starling.supportHighResolutions = true;
+```
+
 Quick Links (AS3)
 -----------------
 

--- a/src/starling/display/BlendMode.hx
+++ b/src/starling/display/BlendMode.hx
@@ -158,6 +158,7 @@ class BlendMode
 	/** Returns true if a blend mode with the given name is available. */
 	public static function isRegistered(modeName:String):Bool
 	{
+		if (sBlendModes == null) registerDefaults();
 		return sBlendModes.exists(modeName);
 	}
 

--- a/src/starling/utils/Execute.hx
+++ b/src/starling/utils/Execute.hx
@@ -28,6 +28,8 @@ class Execute
             var maxNumArgs:Int = untyped ($nargs)(func);
             #elseif cpp
             var maxNumArgs:Int = untyped func.__ArgCount();
+			#elseif html5
+			var maxNumArgs:Int = untyped func.length;
             #else
             var maxNumArgs:Int = -1;
             #end


### PR DESCRIPTION
if you call this when your main Starling class is created or added to stage, it results in an error because sBlendModes is null. Other BlendMode methods check for this and call registerDefaults() if needed so I did the same